### PR TITLE
Fix date format on lock screen for nb locale

### DIFF
--- a/po/nb.po
+++ b/po/nb.po
@@ -1266,7 +1266,7 @@ msgstr "Lukk"
 #. long format */
 #: ../js/ui/screenShield.js:88
 msgid "%A, %B %d"
-msgstr "%A, %B %d"
+msgstr "%A %e. %B"
 
 #: ../js/ui/screenShield.js:153
 #, javascript-format


### PR DESCRIPTION
Should output "tirsdag 2. mai" instead of "tirsdag, mai 02".
