### PR TITLE
Enhance print messages for gnome-shell-extension-tool

### DIFF
--- a/src/gnome-shell-extension-tool.in
+++ b/src/gnome-shell-extension-tool.in
@@ -153,8 +153,8 @@ def enable_extension(uuid):
         sys.exit(1)
 
     extensions.append(uuid)
+    print("Enabling extension %r asynchronously, please check that log contains no error." % (uuid,), file=sys.stderr)
     settings.set_strv(ENABLED_EXTENSIONS_KEY, extensions)
-    print("%r is now enabled." % (uuid,), file=sys.stderr)
 
 def disable_extension(uuid):
     settings = Gio.Settings(schema='org.gnome.shell')
@@ -169,8 +169,8 @@ def disable_extension(uuid):
     while uuid in extensions:
         extensions.remove(uuid)
 
+    print("Disabling extension %r asynchronously, please check that log contains no error." % (uuid,), file=sys.stderr)
     settings.set_strv(ENABLED_EXTENSIONS_KEY, extensions)
-    print("%r is now disabled." % (uuid,), file=sys.stderr)
 
 def main():
     parser = optparse.OptionParser()


### PR DESCRIPTION
This is quite a detail but, in the `gnome-shell-extension-tool`, since extensions are loaded asynchronously, the tool can't display "is now enabled" without a check.

What I did is simply saying "enabling" then invite the user to check in the logs for errors.

I assume that this tool is a low-level tool so I don't mind employing a tech vocabulary here.

thanks
