### PR TITLE
authPrompt: PAM message wrap_line failed.

### DIFF
--- a/js/gdm/authPrompt.js
+++ b/js/gdm/authPrompt.js
@@ -5,6 +5,7 @@ const Gio = imports.gi.Gio;
 const Lang = imports.lang;
 const Signals = imports.signals;
 const St = imports.gi.St;
+const Pango = imports.gi.Pango;
 
 const Animation = imports.ui.animation;
 const Batch = imports.gdm.batch;
@@ -113,6 +114,7 @@ const AuthPrompt = new Lang.Class({
         this._message = new St.Label({ opacity: 0,
                                        styleClass: 'login-dialog-message' });
         this._message.clutter_text.line_wrap = true;
+        this._message.clutter_text.ellipsize = Pango.EllipsizeMode.NONE;
         this.actor.add(this._message, { x_fill: false, x_align: St.Align.START, y_align: St.Align.START });
 
         this._buttonBox = new St.BoxLayout({ style_class: 'login-dialog-button-box',

--- a/src/st/st-label.c
+++ b/src/st/st-label.c
@@ -273,6 +273,7 @@ st_label_init (StLabel *label)
 
   label->priv->label = g_object_new (CLUTTER_TYPE_TEXT,
                                      "ellipsize", PANGO_ELLIPSIZE_END,
+                                     "line-wrap", FALSE,
                                      NULL);
   label->priv->text_shadow_pipeline = NULL;
   label->priv->shadow_width = -1.;


### PR DESCRIPTION
 To make wrap-line work by setting clutter_text.line_wrap to
true, we need to ensure that st-label has installed the property
line-wrap already.Then we also need to set ellipsize to default.

https://bugzilla.gnome.org/show_bug.cgi?id=764445