### PR TITLE
Force style guide with .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[*.{xml,am}]
+indent_style = tab
+
+[*.{c,h}]
+indent_size = 2


### PR DESCRIPTION
Most text editors read the .editorconfig. This will naturally force changes to follow the style guidelines.