### PR TITLE
use bash instead of sh

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Run this to generate all the initial makefiles, etc.
 
 srcdir=`dirname $0`


### PR DESCRIPTION
I was getting an error, trying to run build on Kali Linux:
"**Error**: Directory `/home/andranik/jhbuild/checkout/gnome-shell' does not look like the top-level gnome-shell directory"
Error fixed after change made.