### PR TITLE
Fixed long titles in overview

### DIFF
--- a/js/ui/workspace.js
+++ b/js/ui/workspace.js
@@ -556,6 +556,9 @@ var WindowOverlay = new Lang.Class({
         let borderWidth = cloneWidth + 2 * this.borderSize;
         let borderHeight = cloneHeight + 2 * this.borderSize;
 
+        if (title.width >= borderWidth)
+            title.width = borderWidth;
+
         if (animate) {
             this._animateOverlayActor(this.border, borderX, borderY,
                                       borderWidth, borderHeight);


### PR DESCRIPTION
I built an extension first [HERE](https://github.com/Naheel-Azawy/gnome-shell-extension-overview-titles) but I thought it should be considered as a fix not as an improvement ;)