### PR TITLE
Make use of mutter instead of shell.overrides.

### DIFF
--- a/js/ui/workspaceThumbnail.js
+++ b/js/ui/workspaceThumbnail.js
@@ -31,7 +31,7 @@ var WORKSPACE_CUT_SIZE = 10;
 
 var WORKSPACE_KEEP_ALIVE_TIME = 100;
 
-const OVERRIDE_SCHEMA = 'org.gnome.shell.overrides';
+const OVERRIDE_SCHEMA = 'org.gnome.mutter';
 
 /* A layout manager that requests size only for primary_actor, but then allocates
    all using a fixed layout */

--- a/js/ui/workspacesView.js
+++ b/js/ui/workspacesView.js
@@ -24,7 +24,7 @@ var AnimationType = {
     FADE: 1
 };
 
-const OVERRIDE_SCHEMA = 'org.gnome.shell.overrides';
+const OVERRIDE_SCHEMA = 'org.gnome.mutter';
 
 var WorkspacesViewBase = new Lang.Class({
     Name: 'WorkspacesViewBase',


### PR DESCRIPTION
I noticed that when I use multiple monitors and go to the overview screen switching workspaces does not make my secondary monitor follow the primary monitor. All my open apps are shown in the secondary monitor. 

I'm not sure if this is the way to solve it but by replacing shell.overrides by mutter the setting workspaces-only-on-primary is being used.
![gnome-shell-screenshot-37ljkz](https://user-images.githubusercontent.com/16189228/41500591-ead702a0-7194-11e8-882a-2aa889606276.png)

This is by no means backward compatible so if it needs to be backwards compatible another solution may be needed.